### PR TITLE
feat: add cookie-based refresh token authentication

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -9,7 +9,7 @@ func SetupMux(cfg *APIConfig) http.Handler {
 	mux := http.NewServeMux()
 
 	// middleware
-	mdCors := cfg.middlewareEnableCORS
+	mdCors := cfg.middlewareHandleCORS
 	mdAuth := cfg.middlewareAuthenticate
 	mdClear := cfg.middlewareCheckClearance
 	mdValidateTxn := cfg.middlewareValidateTxn

--- a/internal/api/api_auth.go
+++ b/internal/api/api_auth.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"fmt"
+	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/YouWantToPinch/pincher-api/internal/auth"
@@ -70,23 +73,8 @@ func (cfg *APIConfig) handleLoginUser(w http.ResponseWriter, r *http.Request) {
 			respondWithError(w, http.StatusInternalServerError, "could not create new access token", err)
 			return
 		}
+		rspPayload := cfg.makeAuthPayload(w, r, &dbUser, accessToken, refreshToken)
 
-		type rspSchema struct {
-			User
-			Token        string `json:"token"`
-			RefreshToken string `json:"refresh_token"`
-		}
-
-		rspPayload := rspSchema{
-			User: User{
-				ID:        dbUser.ID,
-				CreatedAt: dbUser.CreatedAt,
-				UpdatedAt: dbUser.UpdatedAt,
-				Username:  dbUser.Username,
-			},
-			Token:        accessToken,
-			RefreshToken: refreshToken,
-		}
 		if err := tx.Commit(r.Context()); err != nil {
 			respondWithError(w, http.StatusInternalServerError, "", err)
 			return
@@ -96,11 +84,9 @@ func (cfg *APIConfig) handleLoginUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (cfg *APIConfig) handleCheckRefreshToken(w http.ResponseWriter, r *http.Request) {
-	returnUser := r.URL.Query().Has("with-user")
-
-	refreshToken, err := auth.GetBearerToken(r.Header)
+	refreshToken, err := FindRefreshToken(r)
 	if err != nil {
-		respondWithError(w, http.StatusBadRequest, "could not get refresh token from header", err)
+		respondWithError(w, http.StatusBadRequest, "", err)
 		return
 	}
 
@@ -116,41 +102,24 @@ func (cfg *APIConfig) handleCheckRefreshToken(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if returnUser {
-		type rspSchema struct {
-			User
-			Token        string `json:"token"`
-			RefreshToken string `json:"refresh_token"`
-		}
-
-		rspPayload := rspSchema{
-			User: User{
-				ID:        dbUser.ID,
-				CreatedAt: dbUser.CreatedAt,
-				UpdatedAt: dbUser.UpdatedAt,
-				Username:  dbUser.Username,
-			},
-			Token:        accessToken,
-			RefreshToken: refreshToken,
-		}
-		respondWithJSON(w, http.StatusOK, rspPayload)
-	} else {
-		type rspSchema struct {
-			Token string `json:"token"`
-		}
-		rspPayload := rspSchema{
-			Token: accessToken,
-		}
-
-		respondWithJSON(w, http.StatusOK, rspPayload)
-	}
+	rspPayload := cfg.makeAuthPayload(w, r, &dbUser, accessToken, refreshToken)
+	respondWithJSON(w, http.StatusOK, rspPayload)
 }
 
 func (cfg *APIConfig) handleRevokeRefreshToken(w http.ResponseWriter, r *http.Request) {
-	refreshToken, err := auth.GetBearerToken(r.Header)
+	refreshToken, err := FindRefreshToken(r)
 	if err != nil {
-		respondWithError(w, http.StatusBadRequest, "could not get refresh token", err)
+		respondWithError(w, http.StatusBadRequest, "", err)
 		return
+	}
+	if r.Header.Get("X-Auth-Transport") == "cookie" {
+		noCookie := &http.Cookie{
+			Name:     "refresh_token",
+			Value:    "",
+			MaxAge:   -1,
+			HttpOnly: true,
+		}
+		http.SetCookie(w, noCookie)
 	}
 
 	err = cfg.db.RevokeRefreshToken(r.Context(), refreshToken)
@@ -159,4 +128,88 @@ func (cfg *APIConfig) handleRevokeRefreshToken(w http.ResponseWriter, r *http.Re
 	}
 
 	respondWithCode(w, http.StatusNoContent)
+}
+
+// makeAuthPayload prepares and returns a response body relevant to requests
+// governing management of refresh tokens. Callers may optionally omit the
+// refresh token field from the response payload, opting for an HttpOnly cookie
+// instead for browser contexts.
+func (cfg *APIConfig) makeAuthPayload(w http.ResponseWriter, r *http.Request, dbUser *database.User, accessToken, refreshToken string) any {
+	contains := func(sub string) bool { return strings.Contains(r.URL.String(), sub) }
+
+	asksForUser := (contains("/refresh") || contains("/revoke")) && r.URL.Query().Has("with-user")
+	returnUser := (asksForUser || contains("/login")) && dbUser != nil
+	forBrowser := r.Header.Get("X-Auth-Transport") == "cookie"
+
+	var user *User
+	if dbUser != nil {
+		slog.Debug("!= nil! We are doing it.")
+		user = &User{
+			ID:        dbUser.ID,
+			CreatedAt: dbUser.CreatedAt,
+			UpdatedAt: dbUser.UpdatedAt,
+			Username:  dbUser.Username,
+		}
+	}
+
+	if forBrowser {
+		cookie := &http.Cookie{
+			Name:     "refresh_token",
+			Value:    refreshToken,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		}
+		http.SetCookie(w, cookie)
+	}
+
+	// returned fields will vary dependent on whether the
+	// response is meant for a browser
+	if returnUser {
+		if forBrowser {
+			return struct {
+				User
+				Token string `json:"token"`
+			}{
+				User:  *user,
+				Token: accessToken,
+			}
+		} else {
+			return struct {
+				User
+				Token        string `json:"token"`
+				RefreshToken string `json:"refresh_token"`
+			}{
+				User:         *user,
+				Token:        accessToken,
+				RefreshToken: refreshToken,
+			}
+		}
+	} else {
+		return struct {
+			Token string `json:"token"`
+		}{
+			Token: accessToken,
+		}
+	}
+}
+
+// FindRefreshToken attempts to find a refresh token in
+// the Authorization header, unless the X-Auth-Transport
+// header indicates that it should search in an existing
+// refresh_token cookie.
+func FindRefreshToken(r *http.Request) (string, error) {
+	var refreshToken string
+	var err error
+	if r.Header.Get("X-Auth-Transport") != "cookie" {
+		refreshToken, err = auth.GetBearerToken(r.Header)
+		if err != nil {
+			return "", fmt.Errorf("could not get refresh token from Authorization header: %w", err)
+		}
+	} else {
+		refreshToken, err = auth.GetRefreshTokenFromCookie(r)
+		if err != nil {
+			return "", fmt.Errorf("could not get refresh token from refresh_token cookie: %w", err)
+		}
+	}
+	return refreshToken, err
 }

--- a/internal/api/api_config.go
+++ b/internal/api/api_config.go
@@ -32,6 +32,7 @@ type APIConfig struct {
 	platform  string
 	jwtSecret string
 	logger    *slog.Logger
+	origins   map[string]struct{}
 	// apiKeys  *map[string]string
 }
 
@@ -42,7 +43,27 @@ func (cfg *APIConfig) Init(envPath string) error {
 		_ = godotenv.Load(envPath)
 	}
 
+	cfg.origins = map[string]struct{}{}
+	originsVal := os.Getenv("ALLOWED_ORIGINS")
+	if origins := strings.Split(strings.TrimSpace(originsVal), ","); len(origins) > 0 {
+		for _, origin := range origins {
+			cfg.origins[origin] = struct{}{}
+		}
+	}
+
 	cfg.platform = os.Getenv("PLATFORM")
+	// Ensure that if some allowed_origins are provided,
+	// and the platform is dev, any localhost ports relevant
+	// to development are automatically added to the whitelist.
+	if cfg.platform == "dev" && len(cfg.origins) > 0 {
+		devPorts := map[string]struct{}{
+			"3000": {}, // React
+			"5173": {}, // Vite
+		}
+		for k := range devPorts {
+			cfg.origins["http://localhost:"+k] = struct{}{}
+		}
+	}
 
 	cfg.jwtSecret = os.Getenv("JWT_SECRET")
 

--- a/internal/api/api_middleware.go
+++ b/internal/api/api_middleware.go
@@ -16,19 +16,35 @@ type ctxKey string
 
 // middlewareHandleCORS handles preflight OPTIONS requests to
 // tell browsers that cross-origin requests are permitted.
-func (cfg *APIConfig) middlewareEnableCORS(next http.Handler) http.Handler {
-	/* NOTE: Should CORS ever need to be made more restrictive,
-	* this approach ought be used, which checks for dev before being permissive:
-			allowedOrigins := []string{}
-			if cfg.platform == "dev" {
-				allowedOrigins = append(allowedOrigins, "http://localhost:*")
-			}
-	*/
-
+//
+// By default, the API allows any origin. The ALLOWED_ORIGINS
+// environment variable may be set to specify a whitelist as a
+// string separated by commas.
+func (cfg *APIConfig) middlewareHandleCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		if origin := r.Header.Get("Origin"); origin != "" {
+
+			w.Header().Set("Vary", "Origin")
+
+			if len(cfg.origins) > 0 {
+				// use origin whitelist
+				if _, allowed := cfg.origins[origin]; allowed {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
+			} else {
+				// allow any origins
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+			}
+
+		} else {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, PATCH, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Key")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Auth-Transport, X-API-Key")
 
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -77,18 +77,18 @@ func ValidateJWT(tokenString, tokenSecret, algorithm string) (uuid.UUID, error) 
 	}
 }
 
-func GetBearerToken(headers http.Header) (tokenString string, returnErr error) {
+func GetBearerToken(headers http.Header) (string, error) {
 	authSlice, ok := headers["Authorization"]
 	if !ok || len(authSlice) == 0 {
 		return "", errors.New("authorization header missing or empty")
 	}
 	authHeaderVal := authSlice[0]
 	if !strings.HasPrefix(strings.ToLower(authHeaderVal), "bearer ") {
-		return "", errors.New("no token string found")
+		return "", errors.New("expected bearer token, found none")
 	}
 	tokenElements := strings.SplitN(authHeaderVal, " ", 2)
 	if len(tokenElements) != 2 || strings.TrimSpace(tokenElements[1]) == "" {
-		return "", errors.New("bearer presented without token")
+		return "", errors.New("bearer token value missing")
 	}
 	return tokenElements[1], nil
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -91,6 +92,19 @@ func GetBearerToken(headers http.Header) (string, error) {
 		return "", errors.New("bearer token value missing")
 	}
 	return tokenElements[1], nil
+}
+
+// GetRefreshTokenFromCookie looks for a value to be used
+// as a refresh token from a valid refresh_token cookie.
+func GetRefreshTokenFromCookie(r *http.Request) (string, error) {
+	cookie, err := r.Cookie("refresh_token")
+	if err != nil {
+		return "", fmt.Errorf("no refresh_token cookie found: %w", err)
+	}
+	if cookie.Value == "" {
+		return "", errors.New("no refresh token associated with cookie")
+	}
+	return cookie.Value, nil
 }
 
 func MakeRefreshToken() (string, error) {


### PR DESCRIPTION
This branch applies the following changes:
- All origins are allowed by default, but a new ALLOWED_ORIGINS environment variable provides the option of comma-separated whitelisting
- Endpoints requiring refresh tokens to be present now look for them based on the presence of a "X-Auth-Transport" header; if its value is `cookie`, these endpoints will look for the refresh token within the `refresh_token` cookie, if it exists. The same header is checked within the `/login` endpoint, to determine whether or not to send the cookie in question.